### PR TITLE
Init code for pointer analysis

### DIFF
--- a/analysis/pointer/pointer.go
+++ b/analysis/pointer/pointer.go
@@ -1,0 +1,89 @@
+package pointer
+
+import (
+	"fmt"
+	"github.com/system-pclub/GCatch/config"
+	"github.com/system-pclub/GCatch/instinfo"
+	"github.com/system-pclub/GCatch/tools/go/callgraph"
+	"github.com/system-pclub/GCatch/tools/go/mypointer"
+	"github.com/system-pclub/GCatch/tools/go/ssa"
+	"github.com/system-pclub/GCatch/tools/go/ssa/ssautil"
+)
+
+// AnalyzeAllSyncOp first finds all sync operations and corresponding values, which will be returned
+// It then runs the pointer analysis for each value, and return the result
+func AnalyzeAllSyncOp() (*mypointer.Result, []*instinfo.StOpValue) {
+	vecStOpValue := []*instinfo.StOpValue{}
+	for fn, _ := range ssautil.AllFunctions(config.Prog) {
+		if fn == nil {
+			continue
+		}
+		// Note that we scan every available functions here, because we don't know where a chan will be passed to
+		for _,bb := range fn.Blocks {
+			for _,inst := range bb.Instrs {
+				// case 1: traditional
+				v, comment := instinfo.ScanInstFindLockerValue(inst)
+				if v != nil {
+					newStOpValue := &instinfo.StOpValue{
+						Inst:    inst,
+						Value:   v,
+						Comment: comment,
+					}
+					vecStOpValue = append(vecStOpValue, newStOpValue)
+					continue
+				}
+
+				// case 2: channel
+				chs, comments := instinfo.ScanInstFindChanValue(inst)
+				for i, ch := range chs {
+					if ch == nil {
+						continue
+					}
+					newStOpValue := &instinfo.StOpValue{
+						Inst:    inst,
+						Value:   chs[i],
+						Comment: comments[i],
+					}
+					vecStOpValue = append(vecStOpValue, newStOpValue)
+				}
+			}
+		}
+	}
+
+	queries := make(map[ssa.Value]struct{})
+	for _, stOpValue := range vecStOpValue {
+		queries[stOpValue.Value] = struct{}{}
+	}
+	cfg := &mypointer.Config{
+		OLDMains:        nil,
+		Prog:            config.Prog,
+		Reflection:      false,
+		BuildCallGraph:  true,
+		Queries:         queries,
+		IndirectQueries: nil,
+		Log:             nil,
+	}
+	stPtrResult, err := mypointer.Analyze(cfg, config.CallGraph)
+	if err != nil {
+		fmt.Println("Error when querying all channel values:\n",err.Error())
+		return nil, nil
+	}
+
+	// Update config.Callgraph, and create a map from instruction to all its corresponding out edges in CallGraph
+	config.CallGraph = stPtrResult.CallGraph
+
+	config.Inst2CallSite = make(map[ssa.CallInstruction]map[*callgraph.Edge]bool)
+	for _, node := range config.CallGraph.Nodes {
+		for _, out := range node.Out {
+			mapCallSites, boolExist := config.Inst2CallSite[out.Site]
+			if !boolExist {
+				mapCallSites = make(map[*callgraph.Edge]bool)
+				config.Inst2CallSite[out.Site] = mapCallSites
+			}
+
+			mapCallSites[out] = true
+		}
+	}
+
+	return stPtrResult, vecStOpValue
+}

--- a/cmd/GCatch/main.go
+++ b/cmd/GCatch/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/system-pclub/GCatch/analysis/pointer"
 	"github.com/system-pclub/GCatch/checkers/conflictinglock"
 	"github.com/system-pclub/GCatch/checkers/doublelock"
 	"github.com/system-pclub/GCatch/ssabuild"
@@ -193,7 +194,8 @@ func detect(mapCheckerName map[string]bool) {
 		case "conflict":
 			conflictinglock.Detect()
 		case "channel":
-			// todo: add the channel checker here
+			stPtrResult, vecStOpValue := pointer.AnalyzeAllSyncOp()
+			_, _ = stPtrResult, vecStOpValue // TODO: next step is to withdraw sync primitives from these two variables
 		}
 	}
 }

--- a/config/global.go
+++ b/config/global.go
@@ -32,3 +32,4 @@ var VecPathStats [] PathStat
 var CallGraph * callgraph.Graph
 var Inst2Defers map[ssa.Instruction][]*ssa.Defer
 var Defer2Insts map[*ssa.Defer][]ssa.Instruction
+var Inst2CallSite map[ssa.CallInstruction]map[*callgraph.Edge]bool

--- a/instinfo/op.go
+++ b/instinfo/op.go
@@ -2,7 +2,9 @@ package instinfo
 
 import (
 	"github.com/system-pclub/GCatch/tools/go/ssa"
+	"go/token"
 	"go/types"
+	"strconv"
 )
 
 func GetCallName(call *ssa.CallCommon) string {
@@ -22,4 +24,126 @@ func GetCallName(call *ssa.CallCommon) string {
 		return v.Name()
 	}
 	return ""
+}
+
+type StOpValue struct {
+	Inst ssa.Instruction
+	Value ssa.Value
+	Comment string
+}
+
+const Lock, Unlock = "Lock", "Unlock"
+const Send, Recv, Close, MakeChan = "Send", "Recv", "Close", "MakeChan"
+
+func ScanInstFindLockerValue(inst ssa.Instruction) (v ssa.Value, comment string) {
+	v = nil
+	comment = ""
+
+	if inst.Parent().Pkg == nil {
+		return
+	}
+	instCall,ok := inst.(ssa.CallInstruction)
+	if !ok {
+		return
+	}
+
+	args := instCall.Common().Args
+	switch {
+	case IsMutexLock(inst) || IsRwmutexLock(inst):
+		if instCall.Common().IsInvoke() == false {
+			if len(args) == 0 {
+				return
+			}
+			return args[0], Lock
+		} else {
+			return instCall.Common().Value, Lock
+		}
+	case IsMutexUnlock(inst) || IsRwmutexUnlock(inst):
+		if instCall.Common().IsInvoke() == false {
+			if len(args) == 0 {
+				return
+			}
+			return args[0],Unlock
+		} else {
+			return instCall.Common().Value,Unlock
+		}
+	default:
+		return
+	}
+}
+
+// ScanInstFindChanValue return multiple values and strings, only when inst is Select
+func ScanInstFindChanValue(inst ssa.Instruction) ([]ssa.Value,[]string) {
+	if inst.Parent().Pkg == nil {
+		return nil,nil
+	}
+
+	boolIsClose := IsChanClose(inst)
+
+	var ssaValueOfPrimitive ssa.Value
+	switch concrete := inst.(type) {
+	case *ssa.Send:
+		return []ssa.Value{concrete.Chan},[]string{Send}
+	case *ssa.UnOp:
+		if concrete.Op == token.ARROW {
+			return []ssa.Value{concrete.X},[]string{Recv}
+		}
+	case ssa.CallInstruction:
+		if boolIsClose {
+			return concrete.Common().Args,[]string{Close}
+		}
+	case *ssa.MakeChan:
+		ssaValueOfPrimitive = concrete
+		return []ssa.Value{ssaValueOfPrimitive},[]string{MakeChan}
+	case *ssa.Select:
+		// Return one value and comment for each case in Select
+		vecSsaValue := []ssa.Value{}
+		vecComment := []string{}
+		for i, state := range concrete.States {
+			vecSsaValue = append(vecSsaValue, state.Chan)
+			if concrete.Blocking {
+				if state.Dir == types.SendOnly {
+					vecComment = append(vecComment,"Blocking_Select_Send_"+strconv.Itoa(i))
+				} else {
+					vecComment = append(vecComment,"Blocking_Select_Recv_"+strconv.Itoa(i))
+				}
+			} else {
+				if state.Dir == types.SendOnly {
+					vecComment = append(vecComment,"Non_Blocking_Select_Send_"+strconv.Itoa(i))
+				} else {
+					vecComment = append(vecComment,"Non_Blocking_Select_Recv_"+strconv.Itoa(i))
+				}
+			}
+		}
+		return vecSsaValue, vecComment
+	}
+
+	return nil,nil
+}
+
+func IsChanClose(inst ssa.Instruction) bool {
+	var call *ssa.CallCommon
+	instCall, ok := inst.(*ssa.Call)
+
+
+
+	if ok {
+		call = instCall.Common()
+	}
+
+	deferIns, ok := inst.(*ssa.Defer)
+	if ok {
+		call = deferIns.Common()
+	}
+
+	if call != nil {
+		if !call.IsInvoke() {
+			callName := GetCallName(call)
+			if callName == "close" {
+				return true
+			}
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
This PR contains the first three stages of pointer analysis:
1. Scan all instructions, and record the ssa.Value that represents a channel or Mutex/RWMutex in each instruction
2. Give all these ssa.Value to the queries in pointer analysis, and run the pointer analysis
3. Store the result of pointer analysis, and update callgraph