### PR TITLE
Define structs of channel and Locker, which will be used later in alias analysis and constraint generation

### DIFF
--- a/instinfo/channel.go
+++ b/instinfo/channel.go
@@ -1,0 +1,129 @@
+package instinfo
+
+import "github.com/system-pclub/GCatch/tools/go/ssa"
+
+// This file defines primitive channel and its operations
+
+// Define Channel
+type Channel struct {
+	Name string
+	Make_inst *ssa.MakeChan
+	Make *ChMake
+	Pkg string
+	Buffer int
+
+	Sends []*ChSend
+	Recvs []*ChRecv
+	Closes []*ChClose
+
+	Status string
+}
+
+// Define interface ChanOp, and its implementation ChOp, which is inherited by all concrete implementations
+type ChanOp interface {
+	Prim() *Channel
+	Instr() ssa.Instruction
+}
+
+type ChOp struct {
+	Parent *Channel
+	Inst ssa.Instruction
+}
+
+func (op *ChOp) Prim() *Channel {
+	return op.Parent
+}
+
+func (op *ChOp) Instr() ssa.Instruction {
+	return op.Inst
+}
+
+// 		Define operation ChMake, a concrete implementation of ChanOp
+type ChMake struct {
+	ChOp // inst can only be MakeChan
+}
+
+// 		Define operation ChSend, a concrete implementation of ChanOp
+type ChSend struct {
+	Name           string
+	CaseIndex      int // If Inst is *ssa.Send, CaseIndex = -1; else CaseIndex is the index of case of *ssa.Select
+	IsCaseBlocking bool
+	Whole_line     string // Used for debug
+	Status         string
+
+	ChOp // this can be *ssa.Send or *ssa.Select
+}
+
+// 		Define operation ChRecv, a concrete implementation of ChanOp
+type ChRecv struct {
+	Name string
+	Case_index int // If Inst is *ssa.UnOp, CaseIndex = -1; else CaseIndex is the index of case of *ssa.Select
+	Is_case_blocking bool
+	Whole_line string // Used for debug
+	Status string
+
+	ChOp // inst can be *ssa.UnOp or *ssa.Select
+}
+
+// 		Define operation ChClose, a concrete implementation of ChanOp
+type ChClose struct {
+	Name string
+	Is_defer bool
+	Whole_line string
+	Status string // Used for debug
+
+	ChOp // inst can be *ssa.Call or *ssa.Defer
+}
+
+// A map from inst to its corresponding LockerOp
+var mapInst2ChanOp map[ssa.Instruction]map[ChanOp]bool
+
+func ClearChanOpMap() {
+	mapInst2ChanOp = make(map[ssa.Instruction]map[ChanOp]bool)
+}
+
+// Define some special channels and its operations
+var ChanTimer Channel
+var ChanContext Channel
+var ChanNotDepend Channel
+
+// Add a special send, belongs to a channel that we don't consider in this run, because it is not a dependent primitive
+// No sync constraint will be generated for this operation.
+// Fields like Case_index need to be updated
+func AddNotDependSend(inst ssa.Instruction) *ChSend {
+	newSend := &ChSend{
+		ChOp:            ChOp{
+			Parent: &ChanNotDepend,
+			Inst:   inst,
+		},
+	}
+	ChanNotDepend.Sends = append(ChanNotDepend.Sends, newSend)
+	return newSend
+}
+
+// Add a special receive, belongs to a channel that we don't consider in this run, because it is not a dependent primitive
+// No sync constraint will be generated for this operation.
+// Fields like Case_index need to be updated
+func AddNotDependRecv(inst ssa.Instruction) *ChRecv {
+	newRecv := &ChRecv{
+		ChOp:            ChOp{
+			Parent: &ChanNotDepend,
+			Inst:   inst,
+		},
+	}
+	ChanNotDepend.Recvs = append(ChanNotDepend.Recvs, newRecv)
+	return newRecv
+}
+
+// Add a special close, belongs to a channel that we don't consider in this run, because it is not a dependent primitive
+// No sync constraint will be generated for this operation.
+func AddNotDependClose(inst ssa.Instruction) *ChClose {
+	newClose := &ChClose{
+		ChOp:            ChOp{
+			Parent: &ChanNotDepend,
+			Inst:   inst,
+		},
+	}
+	ChanNotDepend.Closes = append(ChanNotDepend.Closes, newClose)
+	return newClose
+}

--- a/instinfo/locker.go
+++ b/instinfo/locker.go
@@ -1,0 +1,86 @@
+package instinfo
+
+import "github.com/system-pclub/GCatch/tools/go/ssa"
+
+// This file defines primitive Locker and its operations
+// Locker has similar definitions to Channel in channel.go
+// They are used by the BMOC checker, not traditional checkers
+// Locker includes Mutex and RWMutex, and doesn't handle RLock and RUnlock of RWMutex
+
+// Define Locker
+type Locker struct{
+	Name string
+	Type string
+	Locks []*LockOp
+	Unlocks []*UnlockOp
+	Pkg string // Don't use *ssa.Package here! It's not reliable
+	Value ssa.Value
+
+	Status string
+}
+
+func (l *Locker) AllOps() []LockerOp {
+	vecOp := []LockerOp{}
+	for _, lock := range l.Locks {
+		vecOp = append(vecOp, lock)
+	}
+	for _, unlock := range l.Unlocks {
+		vecOp = append(vecOp, unlock)
+	}
+	return vecOp
+}
+
+func (l *Locker) ModifyStatus(str string) {
+	l.Status = str
+}
+
+// Define interface LockerOp and its two implementations
+//		Define LockerOp
+type LockerOp interface {
+	Instr() ssa.Instruction
+	Prim() *Locker
+}
+
+//		Define LockOp
+type LockOp struct {
+	Name    string
+	Inst    ssa.Instruction
+	IsRLock bool
+	IsDefer bool
+
+	Parent *Locker
+}
+
+func (l *LockOp) Instr() ssa.Instruction {
+	return l.Inst
+}
+
+func (l *LockOp) Prim() *Locker {
+	return l.Parent
+}
+
+//		Define UnlockOp
+type UnlockOp struct {
+	Name string
+	Inst ssa.Instruction
+	IsRUnlock bool
+	IsDefer bool
+
+	Parent *Locker
+}
+
+func (u *UnlockOp) Instr() ssa.Instruction {
+	return u.Inst
+}
+
+
+func (u *UnlockOp) Prim() *Locker {
+	return u.Parent
+}
+
+// A map from inst to its corresponding LockerOp
+var mapInst2LockerOp map[ssa.Instruction]LockerOp
+
+func ClearLockerOpMap() {
+	mapInst2LockerOp = make(map[ssa.Instruction]LockerOp)
+}


### PR DESCRIPTION
This PR creates two new files that define the structs of Channel and Locker
Take Channel as an example, we define a primitive Channel, and an interface ChanOp. The interface ChanOp has concrete implementations like ChanSend and ChanRecv. We also define some special channels like ChanTimer, which will be used for some APIs in `time` library.

Note: one implementation of ChanOp is ChOp. It doesn't have concrete meaning, and it is used because otherwise, we need to write concrete methods for every one of ChanSend, ChanRecv, ChanClose... This is because Go doesn't support generics
