### PR TITLE
obtain channels from the result of pointer analysis

### DIFF
--- a/analysis/pointer/pointer.go
+++ b/analysis/pointer/pointer.go
@@ -4,10 +4,13 @@ import (
 	"fmt"
 	"github.com/system-pclub/GCatch/config"
 	"github.com/system-pclub/GCatch/instinfo"
+	"github.com/system-pclub/GCatch/output"
 	"github.com/system-pclub/GCatch/tools/go/callgraph"
 	"github.com/system-pclub/GCatch/tools/go/mypointer"
 	"github.com/system-pclub/GCatch/tools/go/ssa"
 	"github.com/system-pclub/GCatch/tools/go/ssa/ssautil"
+	"strconv"
+	"strings"
 )
 
 // AnalyzeAllSyncOp first finds all sync operations and corresponding values, which will be returned
@@ -86,4 +89,177 @@ func AnalyzeAllSyncOp() (*mypointer.Result, []*instinfo.StOpValue) {
 	}
 
 	return stPtrResult, vecStOpValue
+}
+
+func WithdrawAllChan(stPtrResult *mypointer.Result, vecStOpValue []*instinfo.StOpValue) (result []*instinfo.Channel) {
+	vecStChanOpAndValue := []*instinfo.StOpValue{}
+	for _, syncInstValue := range vecStOpValue {
+		switch syncInstValue.Comment {
+		case instinfo.Send,instinfo.Recv,instinfo.MakeChan,instinfo.Close:
+			vecStChanOpAndValue = append(vecStChanOpAndValue, syncInstValue)
+		default: // Select or Mutex/Cond/Waitgroup
+			if strings.Contains(syncInstValue.Comment,"Select_") {
+				vecStChanOpAndValue = append(vecStChanOpAndValue, syncInstValue)
+			}
+		}
+	}
+
+	label2ChOp := mergeAlias(vecStChanOpAndValue, stPtrResult)
+	for label, ch_ops := range label2ChOp {
+		boolInContext := boolIsInContext(label.Value())
+		boolInTime := boolIsInTime(label.Value())
+
+		var chPrim *instinfo.Channel
+		if boolInContext { // let these ops belong to a special channel
+			chPrim = &instinfo.ChanContext
+		} else if boolInTime {
+			chPrim = &instinfo.ChanTimer
+		} else {
+			chPrim = &instinfo.Channel{
+				Name:      "",
+				MakeInst: nil,
+				Pkg:       "",
+				Buffer:    0,
+				Sends:     nil,
+				Recvs:     nil,
+				Closes:    nil,
+				Status:    "",
+			}
+			result = append(result, chPrim)
+		}
+
+		for _, chOp := range ch_ops {
+			switch chOp.Comment {
+			case instinfo.MakeChan:
+				new_make := &instinfo.ChMake{
+					ChOp: instinfo.ChOp{
+						Parent: chPrim,
+						Inst:   chOp.Inst,
+					},
+				}
+
+				chPrim.Make = new_make
+				chPrim.MakeInst = chOp.Inst.(*ssa.MakeChan)
+				pkg := chOp.Inst.Parent().Pkg
+				if pkg != nil {
+					chPrim.Pkg = pkg.String()
+				} else {
+					chPrim.Pkg = ""
+				}
+				instMakechan,ok := chOp.Inst.(*ssa.MakeChan)
+				if !ok {
+					fmt.Println("Error: convert inst to *ssa.MakeChan failed. Inst:")
+					output.PrintIISrc(chOp.Inst)
+					continue
+				}
+				// store the buffer size
+				bv := instMakechan.Size
+				bvConst,ok := bv.(*ssa.Const)
+				if !ok { // Dynamic size
+					chPrim.Buffer = instinfo.DynamicSize
+					continue
+				}
+				defer func(inst ssa.Instruction) {
+					if r := recover(); r != nil { // I am concerned that bvConst.Int64() may panic, though it never happens
+						fmt.Println("Recovered when dealing with:",inst)
+						output.PrintIISrc(inst)
+					}
+				}(chOp.Inst)
+				intBuffer := bvConst.Int64()
+				chPrim.Buffer = int(intBuffer)
+
+			case instinfo.Send:
+				newSend := &instinfo.ChSend{
+					CaseIndex:       -1,
+					IsCaseBlocking: false,
+					Status:           "",
+					ChOp:		      instinfo.ChOp{
+						Parent: chPrim,
+						Inst:   chOp.Inst,
+					},
+				}
+				chPrim.Sends = append(chPrim.Sends, newSend)
+			case instinfo.Recv:
+				newRecv := &instinfo.ChRecv{
+					CaseIndex:       -1,
+					IsCaseBlocking: false,
+					Status:           "",
+					ChOp:            instinfo.ChOp{
+						Parent: chPrim,
+						Inst:   chOp.Inst,
+					},
+				}
+				chPrim.Recvs = append(chPrim.Recvs, newRecv)
+			case instinfo.Close:
+				_, boolIsDefer := chOp.Inst.(*ssa.Defer)
+				newClose := &instinfo.ChClose{
+					IsDefer: boolIsDefer,
+					Status:  "",
+					ChOp:    instinfo.ChOp{
+						Parent: chPrim,
+						Inst:   chOp.Inst,
+					},
+				}
+				chPrim.Closes = append(chPrim.Closes, newClose)
+			default:
+				//Select
+				if i := strings.Index(chOp.Comment,"Select_Send_"); i>-1 {
+					var boolIsBlocking bool
+					if strings.HasPrefix(chOp.Comment,"Non_Blocking") {
+						boolIsBlocking = false
+					} else {
+						boolIsBlocking = true
+					}
+					caseIndex,err := strconv.Atoi(chOp.Comment[i+12:])
+					if err != nil {
+						fmt.Println("Error when conv str to int for select inst:",err)
+						output.PrintIISrc(chOp.Inst)
+					}
+					newSend := &instinfo.ChSend{
+						CaseIndex:      caseIndex,
+						IsCaseBlocking: boolIsBlocking,
+						Status:         "",
+						ChOp:            instinfo.ChOp{
+							Parent: chPrim,
+							Inst:   chOp.Inst,
+						},
+					}
+					chPrim.Sends = append(chPrim.Sends, newSend)
+				} else if i := strings.Index(chOp.Comment,"Select_Recv_"); i>-1 {
+					var boolIsBlocking bool
+					if strings.HasPrefix(chOp.Comment,"Non_Blocking") {
+						boolIsBlocking = false
+					} else {
+						boolIsBlocking = true
+					}
+					caseIndex,err := strconv.Atoi(chOp.Comment[i+12:])
+					if err != nil {
+						fmt.Println("Error when conv str to int for select inst:",err)
+						output.PrintIISrc(chOp.Inst)
+					}
+					new_recv := &instinfo.ChRecv{
+						CaseIndex:      caseIndex,
+						IsCaseBlocking: boolIsBlocking,
+						Status:         "",
+						ChOp:            instinfo.ChOp{
+							Parent: chPrim,
+							Inst:   chOp.Inst,
+						},
+					}
+					chPrim.Recvs = append(chPrim.Recvs,new_recv)
+				}
+			}
+		}
+
+		if !boolInContext && !boolInTime {
+			recordChInstToMap(chPrim)
+		}
+	}
+
+	recordChInstToMap(&instinfo.ChanTimer)
+	recordChInstToMap(&instinfo.ChanContext)
+	result = append(result, &instinfo.ChanTimer)
+	result = append(result, &instinfo.ChanContext)
+
+	return
 }

--- a/analysis/pointer/utils.go
+++ b/analysis/pointer/utils.go
@@ -1,0 +1,71 @@
+package pointer
+
+import (
+	"github.com/system-pclub/GCatch/instinfo"
+	"github.com/system-pclub/GCatch/tools/go/mypointer"
+	"github.com/system-pclub/GCatch/tools/go/ssa"
+	"strings"
+)
+
+func mergeAlias(vecinstValue []*instinfo.StOpValue, stPtrResult *mypointer.Result) (result map[mypointer.Label][]*instinfo.StOpValue) {
+	result = make(map[mypointer.Label][]*instinfo.StOpValue)
+	for _, instValue := range vecinstValue {
+		labels := stPtrResult.Queries[instValue.Value].PointsTo().Labels()
+		for _, label := range labels {
+			_, ok := result[*label]
+			if ok {
+				result[*label] = append(result[*label], instValue)
+			} else {
+				result[*label] = []*instinfo.StOpValue{instValue}
+			}
+		}
+	}
+
+	return
+}
+
+func boolIsInContext(v ssa.Value) bool {
+	if v == nil || v.Parent() == nil || v.Parent().Pkg == nil || v.Parent().Pkg.Pkg == nil {
+		return false
+	}
+	strPkg := v.Parent().Pkg.Pkg.Path()
+	if strPkg == "context" || strings.Contains(strPkg,"golang.org/x/net/context") { // some people still
+		// import golang.org/x/net/context
+		return true
+	}
+	return false
+}
+
+func boolIsInTime(v ssa.Value) bool {
+	if v == nil || v.Parent() == nil || v.Parent().Pkg == nil || v.Parent().Pkg.Pkg == nil {
+		return false
+	}
+	strPkg := v.Parent().Pkg.Pkg.Path()
+	if strPkg == "time" {
+		return true
+	}
+	return false
+}
+
+func recordChInstToMap(chPrim *instinfo.Channel) {
+	if chPrim.MakeInst != nil {
+		instinfo.MapInst2ChanOp[chPrim.MakeInst] = map[instinfo.ChanOp]bool{chPrim.Make: true,}
+	}
+
+	for _, send := range chPrim.Sends {
+		if send.Inst != nil {
+			instinfo.MapInst2ChanOp[send.Inst] = map[instinfo.ChanOp]bool{send: true,}
+		}
+	}
+	for _, recv := range chPrim.Recvs {
+		if recv.Inst != nil {
+			instinfo.MapInst2ChanOp[recv.Inst] = map[instinfo.ChanOp]bool{recv: true,}
+		}
+	}
+	for _, c := range chPrim.Closes {
+		if c != nil {
+			instinfo.MapInst2ChanOp[c.Inst] = map[instinfo.ChanOp]bool{c: true,}
+		}
+	}
+
+}

--- a/checkers/bmoc/bmoc.go
+++ b/checkers/bmoc/bmoc.go
@@ -1,0 +1,9 @@
+package bmoc
+
+import "github.com/system-pclub/GCatch/analysis/pointer"
+
+func Detect() {
+	stPtrResult, vecStOpValue := pointer.AnalyzeAllSyncOp()
+	vecChannel := pointer.WithdrawAllChan(stPtrResult, vecStOpValue)
+	_ = vecChannel	// TODO: Withdraw all Lockers
+}

--- a/cmd/GCatch/main.go
+++ b/cmd/GCatch/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/system-pclub/GCatch/analysis/pointer"
+	"github.com/system-pclub/GCatch/checkers/bmoc"
 	"github.com/system-pclub/GCatch/checkers/conflictinglock"
 	"github.com/system-pclub/GCatch/checkers/doublelock"
 	"github.com/system-pclub/GCatch/ssabuild"
@@ -194,8 +194,7 @@ func detect(mapCheckerName map[string]bool) {
 		case "conflict":
 			conflictinglock.Detect()
 		case "channel":
-			stPtrResult, vecStOpValue := pointer.AnalyzeAllSyncOp()
-			_, _ = stPtrResult, vecStOpValue // TODO: next step is to withdraw sync primitives from these two variables
+			bmoc.Detect()
 		}
 	}
 }

--- a/instinfo/channel.go
+++ b/instinfo/channel.go
@@ -7,7 +7,7 @@ import "github.com/system-pclub/GCatch/tools/go/ssa"
 // Define Channel
 type Channel struct {
 	Name string
-	Make_inst *ssa.MakeChan
+	MakeInst *ssa.MakeChan
 	Make *ChMake
 	Pkg string
 	Buffer int
@@ -48,7 +48,7 @@ type ChSend struct {
 	Name           string
 	CaseIndex      int // If Inst is *ssa.Send, CaseIndex = -1; else CaseIndex is the index of case of *ssa.Select
 	IsCaseBlocking bool
-	Whole_line     string // Used for debug
+	WholeLine     string // Used for debug
 	Status         string
 
 	ChOp // this can be *ssa.Send or *ssa.Select
@@ -57,9 +57,9 @@ type ChSend struct {
 // 		Define operation ChRecv, a concrete implementation of ChanOp
 type ChRecv struct {
 	Name string
-	Case_index int // If Inst is *ssa.UnOp, CaseIndex = -1; else CaseIndex is the index of case of *ssa.Select
-	Is_case_blocking bool
-	Whole_line string // Used for debug
+	CaseIndex int // If Inst is *ssa.UnOp, CaseIndex = -1; else CaseIndex is the index of case of *ssa.Select
+	IsCaseBlocking bool
+	WholeLine string // Used for debug
 	Status string
 
 	ChOp // inst can be *ssa.UnOp or *ssa.Select
@@ -68,19 +68,21 @@ type ChRecv struct {
 // 		Define operation ChClose, a concrete implementation of ChanOp
 type ChClose struct {
 	Name string
-	Is_defer bool
-	Whole_line string
+	IsDefer bool
+	WholeLine string
 	Status string // Used for debug
 
 	ChOp // inst can be *ssa.Call or *ssa.Defer
 }
 
 // A map from inst to its corresponding LockerOp
-var mapInst2ChanOp map[ssa.Instruction]map[ChanOp]bool
+var MapInst2ChanOp map[ssa.Instruction]map[ChanOp]bool
 
 func ClearChanOpMap() {
-	mapInst2ChanOp = make(map[ssa.Instruction]map[ChanOp]bool)
+	MapInst2ChanOp = make(map[ssa.Instruction]map[ChanOp]bool)
 }
+
+const DynamicSize = -999 // If a channel's buffer size can't be computed statically, we give DynamicSize to the Buffer field
 
 // Define some special channels and its operations
 var ChanTimer Channel


### PR DESCRIPTION
1. Add checker bmoc, and move the pointer analysis of channel into bmoc.Detect()

2. Small changes in channel.go: 
Change field names; add a constant for dynamic buffer size

3. The next step of pointer analysis: 
From the result of pointer analysis, identify operations that belong to the same channel, and create a vector of instinfo.Channel for these channels