### PR TITLE
Followup: Type definition and related functions for the syncgraph

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 const MAX_SECOND = 1800000
 const POINTER_CONSIDER_REFLECTION = false
 const MAX_LCA_LAYER = 5 // The maximum caller-callee layers when updating dependency map and finding LCA (Lowest Common Ancester)
+const DISABLE_OPTIMIZATION_CALLEES = false // If set to false, we won't enter every callee while building syncgraph
 
 // flag constants
 const ConstPrintDeferMap = "print-defer-map"

--- a/syncgraph/path.go
+++ b/syncgraph/path.go
@@ -1,0 +1,220 @@
+package syncgraph
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"github.com/system-pclub/GCatch/output"
+	"github.com/system-pclub/GCatch/tools/go/ssa"
+	"strconv"
+	"strings"
+)
+
+
+type tupleGoroutinePath struct {
+	goroutine *Goroutine
+	path *LocalPath
+}
+
+type pathCombination struct { // []'s length is len(g.Goroutines). Every tupleGoroutinePath.Goroutine is unique
+	go_paths []*tupleGoroutinePath
+}
+
+
+type EnumeConfigure struct {
+	Unfold             int
+	IgnoreFn           map[*ssa.Function]struct{} // a map of not interesting
+	FlagIgnoreNoSyncFn bool
+	FlagIgnoreNormal   bool
+}
+
+type LocalPath struct {
+	Path                   []Node
+	Hash                   string
+	mapNodeEdge2IntVisited map[*NodeEdge]int
+	//finished bool
+}
+
+
+var intEmptyPathId int
+func NewEmptyPath() *LocalPath {
+	intEmptyPathId++
+	return &LocalPath{
+		Path:                   []Node{},
+		Hash:                   "Empty_path_NO." + strconv.Itoa(intEmptyPathId),
+		mapNodeEdge2IntVisited: nil,
+	}
+}
+
+func (l *LocalPath) IsEmpty() bool {
+	return strings.HasPrefix(l.Hash, "Empty_path_NO.")
+}
+
+type PNode struct { // A Node will have n PNode if it shows up n times in path
+	Path     *LocalPath
+	Index    int
+	Node     Node
+	Blocked  bool
+	Executed bool
+}
+
+type PPath struct {
+	Path      []*PNode
+	localPath *LocalPath
+}
+
+
+func (p PPath) IsNodeIn(node Node) bool {
+	for _,t_n := range p.Path {
+		if t_n.Node == node {
+			return true
+		}
+	}
+	return false
+}
+
+func (p PPath) SetAllReached() {
+	for _,n := range p.Path {
+		n.Blocked = false
+		n.Executed = true
+	}
+}
+
+func (p PPath) SetBlockAt(index int) {
+	for i,n := range p.Path {
+		if i < index {
+			n.Executed = true
+			n.Blocked = false
+		} else if i == index {
+			n.Executed = false
+			n.Blocked = true
+		} else {
+			n.Executed = false
+			n.Blocked = false
+		}
+	}
+}
+
+var mapHash2Map map[string]*LocalPath
+
+type tupleCallerCallee struct {
+	caller Node
+	callee Node
+}
+
+func deleteNormalFromPath(oldPath *LocalPath) *LocalPath {
+	newSlice := []Node{}
+	for _, node := range oldPath.Path {
+		if _, boolIsNormal := node.(*NormalInst); boolIsNormal {
+			continue
+		}
+		newSlice = append(newSlice, node)
+	}
+
+	newLocalPath := &LocalPath{
+		Path:                   newSlice,
+		Hash:                   hashOfPath(newSlice),
+		mapNodeEdge2IntVisited: copyBackedgeMap(oldPath.mapNodeEdge2IntVisited),
+	}
+	oldPath = nil
+	return newLocalPath
+}
+
+func copyLocalPath(old *LocalPath) *LocalPath {
+	newLocalPath := &LocalPath{
+		Path:                   copyPathSlice(old.Path),
+		Hash:                   old.Hash,
+		mapNodeEdge2IntVisited: copyBackedgeMap(old.mapNodeEdge2IntVisited),
+	}
+	return newLocalPath
+}
+
+func debugPrintEnumeratedPaths(path_map map[string]*LocalPath) {
+	count := 0
+	fmt.Println("In total:", len(path_map))
+	for _,path := range path_map {
+		fmt.Println("-----Path:", count)
+		fmt.Println(path.mapNodeEdge2IntVisited)
+		count++
+		for i,n := range path.Path {
+			str := TypeMsgForNode(n)
+			if str == "Normal_inst" {
+				continue
+			}
+			fmt.Println(str)
+			if i < len(path.Path) - 1 {
+				var flag_backedge bool
+				next := path.Path[i+1]
+				for _,out := range n.Out() {
+					if out.Succ == next {
+						flag_backedge = out.IsBackedge
+						break
+					}
+				}
+				if flag_backedge {
+					fmt.Println("--Backedge")
+				}
+			}
+			if i == len(path.Path) - 1 {
+				if TypeMsgForNode(n) != "Return" {
+					output.WaitForInput()
+				}
+			}
+		}
+		output.WaitForInput()
+	}
+}
+
+
+func copyBackedgeMap(old map[*NodeEdge]int) map[*NodeEdge]int {
+	n := make(map[*NodeEdge]int)
+	for key,value := range old {
+		n[key] = value
+	}
+	return n
+}
+
+func copyPathMap(old map[string]*LocalPath) map[string]*LocalPath {
+	n := make(map[string]*LocalPath)
+	for key,value := range old {
+		n[key] = value
+	}
+	return n
+}
+
+func copyPathSlice(old []Node) []Node {
+	copy_path := []Node{}
+	for _,n := range old {
+		copy_path = append(copy_path, n)
+	}
+	return copy_path
+}
+
+func copyIntSlice(old []int) []int {
+	n := []int{}
+	for _, o := range old {
+		n = append(n, o)
+	}
+	return n
+}
+
+func hashOfPath(node []Node) string {
+	var buffer bytes.Buffer
+	for _,n := range node {
+		buffer.WriteString(strconv.Itoa(n.GetId())+" ")
+	}
+	byte_key := buffer.Bytes()
+	hash := sha256.Sum256(byte_key)
+	return string(hash[:])
+}
+
+func removeFromPathWorklist(old_worklist []*LocalPath, remove *LocalPath) []*LocalPath {
+	result := []*LocalPath{}
+	for _,o := range old_worklist {
+		if o == remove {
+			continue
+		}
+		result = append(result, o)
+	}
+	return result
+}

--- a/syncgraph/task.go
+++ b/syncgraph/task.go
@@ -1,0 +1,273 @@
+package syncgraph
+
+import (
+	"fmt"
+	"github.com/system-pclub/GCatch/config"
+	"github.com/system-pclub/GCatch/instinfo"
+	"github.com/system-pclub/GCatch/output"
+	"github.com/system-pclub/GCatch/path"
+	"github.com/system-pclub/GCatch/tools/go/callgraph"
+	"github.com/system-pclub/GCatch/tools/go/ssa"
+)
+
+type Task struct {
+	VecTaskPrimitive       []*TaskPrimitive // VecTaskPrimitive means these primitives satify: all its operations are in the graph
+	MapValue2TaskPrimitive map[interface{}]*TaskPrimitive
+	MapLCARoot2Op          map[*ssa.Function][]*ChainsToReachOp
+	BoolFinished           bool
+}
+
+type TaskPrimitive struct {
+	Primitive interface{}
+	Ops map[interface{}]*ChainsToReachOp
+	Finished bool
+	Task *Task
+}
+
+// Operation of a primitive, context-sensitive
+// E.g. func send() { ch <- 1}
+//		func main() {
+//			send() // Line 3
+//			send() // Line 4
+//		}
+// There are 2 operations, called by two paths: main() ---Line3---> send(); main() ---Line4---> send()
+type ChainsToReachOp struct{
+	Op                     interface{}
+	Inst                   ssa.Instruction
+	Chains                 []*path.EdgeChain
+	VecBoolIsChainFinished []bool
+	Finished               bool
+}
+
+func newTask() *Task {
+	return &Task{
+		VecTaskPrimitive:       nil,
+		MapValue2TaskPrimitive: make(map[interface{}]*TaskPrimitive),
+		MapLCARoot2Op:          make(map[*ssa.Function][]*ChainsToReachOp),
+		BoolFinished:           false,
+	}
+}
+
+// After this function, a new primitive is added to the task, but TaskPrimitive.Ops are not completed. Need to run Step2CompletePrims after adding all primitives
+func (t *Task) Step1AddPrim(newP interface{}) {
+	newTPrimitive := &TaskPrimitive{
+		Primitive: newP,
+		Ops:       make(map[interface{}]*ChainsToReachOp),
+		Finished:  false,
+		Task:      t,
+	}
+	t.VecTaskPrimitive = append(t.VecTaskPrimitive, newTPrimitive)
+	t.MapValue2TaskPrimitive[newP] = newTPrimitive
+}
+
+// After adding all primitives that we want, complete everything in each TaskPrimitive.Ops
+func (t *Task) Step2CompletePrims() error {
+
+	// Ignore order, list all insts for op in Target_prims
+	vecOpInsts := []ssa.Instruction{}
+	for _, tPrim := range t.VecTaskPrimitive {
+		switch prim := tPrim.Primitive.(type) {
+		case *instinfo.Channel:
+			for _, op := range prim.AllOps() {
+				vecOpInsts = append(vecOpInsts, op.Instr())
+			}
+		case *instinfo.Locker:
+			for _, op := range prim.AllOps() {
+				vecOpInsts = append(vecOpInsts, op.Instr())
+			}
+		}
+	}
+
+	LCA2paths, err := path.FindLCA(fnsForInstsNoDupli(vecOpInsts),config.MAX_LCA_LAYER)
+	if err != nil {
+		if config.DISABLE_OPTIMIZATION_CALLEES && err == path.LcaErrReachedMax {
+			// Do nothing because if the optimization is disabled, then we enter every callee and it is normal to reach max layers
+		} else {
+			return err
+		}
+	}
+	if err == path.LcaErrNilNode {
+		return err
+	}
+
+	for _, tPrim := range t.VecTaskPrimitive {
+		tPrim.CompleteOps(LCA2paths)
+	}
+
+	return nil
+}
+
+func (t *Task) Update() {
+	if t.BoolFinished {
+		return
+	}
+
+	for _,prim := range t.VecTaskPrimitive {
+		if prim.Finished {
+			continue
+		}
+		for _, chainsToReachOp := range prim.Ops {
+			if chainsToReachOp.Finished {
+				continue
+			}
+			boolAllChainFinished := true
+			for _, boolFinished := range chainsToReachOp.VecBoolIsChainFinished {
+				if boolFinished == false {
+					boolAllChainFinished = false
+					break
+				}
+			}
+			chainsToReachOp.Finished = boolAllChainFinished
+		}
+	}
+
+	for _,prim := range t.VecTaskPrimitive {
+		if prim.Finished {
+			continue
+		}
+		boolAllOpFinished := true
+		for _, chainsToReachOp := range prim.Ops {
+			if chainsToReachOp.Finished == false {
+				boolAllOpFinished = false
+				break
+			}
+		}
+		prim.Finished = boolAllOpFinished
+	}
+
+	boolAllPrimFinished := true
+	for _,prim := range t.VecTaskPrimitive {
+		if prim.Finished == false {
+			boolAllPrimFinished = false
+			break
+		}
+	}
+	t.BoolFinished = boolAllPrimFinished
+}
+
+func (t *Task) WantedList() (result []*path.EdgeChain) {
+	if t.BoolFinished {
+		return nil
+	}
+
+	for _,prim := range t.VecTaskPrimitive {
+		if prim.Finished {
+			continue
+		}
+		for _, chainsToReachOp := range prim.Ops {
+			if chainsToReachOp.Finished {
+				continue
+			}
+			for i,chain := range chainsToReachOp.Chains {
+				if chainsToReachOp.VecBoolIsChainFinished[i] {
+					continue
+				}
+
+				// if this chain is not in result, append it
+				boolInResult := false
+				for _, edgeChainResult := range result {
+					if chain.Equal(edgeChainResult) {
+						boolInResult = true
+					}
+				}
+				if boolInResult == false {
+					result = append(result, chain)
+				}
+			}
+		}
+	}
+
+	return result
+}
+
+// A primitive is a target when it is in Task.VecTaskPrimitive
+func (t *Task) IsPrimATarget(prim interface{}) bool {
+	for _, tPrim := range t.VecTaskPrimitive {
+		if tPrim.Primitive == prim {
+			return true
+		}
+	}
+	return false
+}
+
+func removeVisitedChains(vecWanted, vecVisited []*path.EdgeChain) (result []*path.EdgeChain) {
+	for _,wanted := range vecWanted {
+		boolVisited := false
+		for _,visited := range vecVisited {
+			if wanted.Equal(visited) {
+				boolVisited = true
+				break
+			}
+		}
+		if boolVisited == false {
+			result = append(result, wanted)
+		}
+	}
+	return
+}
+
+// Generates tp.Ops, and find all callchains from head to an operation
+func (tp *TaskPrimitive) CompleteOps(LCA2paths map[*ssa.Function][]*path.EdgeChain) {
+	switch p := tp.Primitive.(type) {
+	case *instinfo.Channel:
+		for _,op := range p.AllOps() {
+			new_op := &ChainsToReachOp{
+				Op:                     op,
+				Inst:                   op.Instr(),
+				Chains:                 nil,
+				VecBoolIsChainFinished: nil,
+				Finished:               false,
+			}
+			tp.Ops[op] = new_op
+		}
+	case *instinfo.Locker:
+		for _,op := range p.AllOps() {
+			new_op := &ChainsToReachOp{
+				Op:                     op,
+				Inst:                   op.Instr(),
+				Chains:                 nil,
+				VecBoolIsChainFinished: nil,
+				Finished:               false,
+			}
+			tp.Ops[op] = new_op
+		}
+	}
+
+	for _, chainsToReachOp := range tp.Ops {
+		op_fn := chainsToReachOp.Inst.Parent()
+
+		for lca, paths := range LCA2paths {
+			boolFound := false
+			for _, onePath := range paths {
+				var end *callgraph.Node
+				if len(onePath.Chain) == 0 {
+					end = onePath.Start
+				} else {
+					end = onePath.Chain[len(onePath.Chain) - 1].Callee
+				}
+				if end.Func == op_fn {
+					boolFound = true
+					chainsToReachOp.Chains = append(chainsToReachOp.Chains, onePath)
+					chainsToReachOp.VecBoolIsChainFinished = append(chainsToReachOp.VecBoolIsChainFinished, false)
+				}
+			}
+			if boolFound {
+				tp.Task.MapLCARoot2Op[lca] = append(tp.Task.MapLCARoot2Op[lca], chainsToReachOp)
+			}
+		}
+
+		if len(chainsToReachOp.Chains) == 0 {
+			fmt.Println("Warning in CompleteOps: can't find any chain for op:")
+			output.PrintIISrc(chainsToReachOp.Inst)
+		}
+	}
+}
+
+func removeFromWorklist(old []*Unfinish, remove *Unfinish) (result []*Unfinish) {
+	for _,o := range old {
+		if o != remove {
+			result = append(result, o)
+		}
+	}
+	return
+}


### PR DESCRIPTION
This pull request needs to be merged later than "Define types for the syncgraph"

Completed most of the type definitions needed in package syncgraph: added definitions of PathCombination and Task, together with related functions.

PathCombination is the path combination in paper.
PathCombination is enumerated from the SyncGraph, which contains all instructions on CFG, and also contains more information like alias and callgraph.
Task is used to build the SyncGraph, to track if SyncGraph contains all operations of the channels and mutexes we are interested in.