### PR TITLE
Remove go.mod and go.sum from tools/go directory.

### DIFF
--- a/GCatch/tools/go/go.mod
+++ b/GCatch/tools/go/go.mod
@@ -1,8 +1,0 @@
-module github.com/system-pclub/GCatch/GCatch/tools
-
-go 1.11
-
-require (
-	golang.org/x/net v0.0.0-20190311183353-d8887717615a
-	golang.org/x/sync v0.0.0-20190423024810-112230192c58
-)

--- a/GCatch/tools/go/go.sum
+++ b/GCatch/tools/go/go.sum
@@ -1,7 +1,0 @@
-golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/net v0.0.0-20190311183353-d8887717615a h1:oWX7TPOiFAMXLq8o0ikBYfCJVlRHBcsciT5bXOrH628=
-golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
-golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
This has an incorrect setting for the module which seems to inhibit builds.

This may also require running `go mod init github.com/system-pclub/GCatch/GCatch` in the GCatch/GCatch directory; I hesitate to offer a PR for that because due to #20 my current go.mod has a "replace" directive that should probably be fixed at the root but I don't know whether the replace directive will re-introduce some bug you may have fixed. With that go.mod file added in GCatch/GCatch, this go.mod is unnecessary even if fixed.