### PR TITLE
Improve GCatch/installZ3.sh

### DIFF
--- a/GCatch/installZ3.sh
+++ b/GCatch/installZ3.sh
@@ -1,21 +1,27 @@
-CURDIR=`pwd`
-REPATH='/src/github.com/system-pclub/GCatch/GCatch'
-if [[ "$CURDIR" != *"$REPATH"* ]]
-then
-  echo "Please make sure the current directory is /SOME/PATH/src/github.com/system-pclub/GCatch/GCatch"
-  echo "Current directory: $CURDIR"
-  exit 0
+#!/usr/bin/env bash
+# Install z3 from sources
+# GCatch requires z3 WITH SOURCES
+
+installZ3() {
+  echo "Installing z3 to a default position, normally $Z3"
+  echo "Could fail if run without sudo"
+  cd ./tools/z3 || exit
+  python scripts/mk_make.py
+  cd build || exit
+  make
+  sudo make install
+}
+
+# cd script directory
+cd "$(dirname "$(realpath "$0")")" || exit;
+Z3=/usr/local/bin/z3
+if test -f "$Z3"; then
+  read -p 'GCatch requires z3 WITH SOURCES. Reinstall z3 from sources? [Y/n] ' -r yn
+  case $yn in
+    [Yy]* ) installZ3;;
+    [Nn]* ) exit;;
+    * ) echo "Please answer Y/N";;
+  esac
 else
-  Z3=/usr/local/bin/z3
-  if test -f "$Z3"; then
-    echo "Z3 exists"
-  else
-    echo "Installing Z3 to a default position, normally $Z3"
-    echo "Could fail if ran without sudo"
-    cd ./tools/z3
-    python scripts/mk_make.py
-    cd build
-    make
-    sudo make install
-  fi
+  installZ3
 fi


### PR DESCRIPTION
Fixes #23 Task-1:
1. Auto changes to the directory where the script resides.
2. Exits if dir does not exist for each "cd $dir".
2. Reminds users that z3 must be installed from the source code.
3. Asks if users need to reinstall z3 if it exists.