### PR TITLE
Improve scripts: Check z3 header; Turn off go module; Add comments

### DIFF
--- a/GCatch/install.sh
+++ b/GCatch/install.sh
@@ -1,24 +1,34 @@
-CURDIR=`pwd`
+#!/usr/bin/env bash
+#
+# Install GCatch
+# Before running this script, run installZ3.sh to install z3 from sources
+# GCatch assumes that it has been installed under GOPATH and sets GOPATH accordingly
+# GCatch currently only supports GOPATH instead of go.mod due to legacy issues
+# GCatch turns off the usage of go module
+# GCatch will be installed under GOPATH/bin/
+
+echo "Make sure you have run installZ3.sh"
+
+# cd script directory
+CURDIR="$(dirname "$(realpath "$0")")"
+cd "$CURDIR" || exit 1
+
+# check if under GOPATH
 REPATH='/src/github.com/system-pclub/GCatch/GCatch'
 if [[ "$CURDIR" != *"$REPATH"* ]]
 then
   echo "Please make sure the current directory is /SOME/PATH/src/github.com/system-pclub/GCatch/GCatch"
   echo "Current directory: $CURDIR"
-  exit 0
+  exit 1
 else
-  Z3=/usr/local/bin/z3
-  if test -f "$Z3"; then
-    echo "Z3 exists"
-  else
-    echo "Z3 is not installed in $Z3. Please run installZ3.sh with sudo or checkout https://github.com/Z3Prover/z3 to install Z3"
-    exit 1
-  fi
   echo "Step 1: setting GOPATH to install GCatch"
-  cd ../../../../..
-  export GOPATH=`pwd`
+  GOPATH=$(cd ../../../../.. || exit 1; pwd)
+  export GOPATH
   echo "GOPATH is set to $GOPATH"
   echo "Step 2: installing GCatch"
-  cd $CURDIR/cmd/GCatch
+  cd "$CURDIR"/cmd/GCatch || exit 1
+  # turn off go mod before installation
+  export GO111MODULE=off
   go install
   echo "GCatch is installed in $GOPATH/bin/GCatch"
 fi

--- a/GCatch/installZ3.sh
+++ b/GCatch/installZ3.sh
@@ -1,27 +1,40 @@
 #!/usr/bin/env bash
+#
 # Install z3 from sources
 # GCatch requires z3 WITH SOURCES
+# You can also checkout https://github.com/Z3Prover/z3 to install Z3
 
 installZ3() {
   echo "Installing z3 to a default position, normally $Z3"
   echo "Could fail if run without sudo"
-  cd ./tools/z3 || exit
+  cd ./tools/z3 || exit 1
   python scripts/mk_make.py
-  cd build || exit
+  cd build || exit 1
   make
   sudo make install
 }
 
 # cd script directory
-cd "$(dirname "$(realpath "$0")")" || exit;
-Z3=/usr/local/bin/z3
-if test -f "$Z3"; then
-  read -p 'GCatch requires z3 WITH SOURCES. Reinstall z3 from sources? [Y/n] ' -r yn
+cd "$(dirname "$(realpath "$0")")" || exit 1
+
+# check z3 bin
+if ! Z3=$(command -v z3); then
+  echo 'Cannot detect z3'
+  installZ3
+  exit
+fi
+
+# check z3 header
+if echo '#include <z3.h>' | gcc -H -fsyntax-only -E - 1>/dev/null 2>&1; then
+  read -p 'z3 and <z3.h> exist. Reinstall z3 from sources? [y/N] ' -r yn
   case $yn in
     [Yy]* ) installZ3;;
-    [Nn]* ) exit;;
-    * ) echo "Please answer Y/N";;
+    * ) exit;;
   esac
 else
-  installZ3
+  read -p 'GCatch requires z3 WITH SOURCES. Reinstall z3 from sources? [Y/n] ' -r yn
+  case $yn in
+    [Nn]* ) exit;;
+    * ) installZ3;;
+  esac
 fi

--- a/GCatch/run.sh
+++ b/GCatch/run.sh
@@ -1,42 +1,51 @@
-CURDIR=`pwd`
-REPATH='/src/github.com/system-pclub/GCatch/GCatch'
-if [[ "$CURDIR" != *"$REPATH"* ]]
-then
-  echo "Please make sure the current directory is /SOME/PATH/src/github.com/system-pclub/GCatch/GCatch"
-  echo "Current directory: $CURDIR"
-  exit 0
-else
-  Z3=/usr/local/bin/z3
-  if test -f "$Z3"; then
-    echo "Z3 exists"
-  else
-    echo "Z3 is not installed in $Z3. Please run installZ3.sh with sudo or checkout https://github.com/Z3Prover/z3 to install Z3"
-    exit 1
-  fi
-  cd ../../../../..
-  GCATCH=`pwd`
-  GCATCH=$GCATCH/bin/GCatch
-  if test -f "$GCATCH"; then
-    echo "GCatch exists"
-  else
-    echo "GCatch is not installed in $GCATCH. Please run install.sh to install GCatch"
-    exit 2
-  fi
-  echo "Step 1: setting GOPATH of the checked grpc"
-  export GOPATH=$CURDIR/testdata/grpc-buggy
-  echo "GOPATH is set to $GOPATH"
-  echo ""
-  echo "Description of flags of GCatch:"
-  echo "Required Flag: -path=Full path of the application to be checked"
-  echo "Required Flag: -include=Relative path (what's after /src/) of the application to be checked"
-  echo "Required Flag: -checker=The checkers you want to run, divided by \":\".    Default value:BMOC"
-  echo "Optional Flag: -r    Whether all children packages should also be checked recursively"
-  echo "Optional Flag: -compile-error    Whether compilation errors should be printed, if there are any"
-  echo "Optional Flag: -vendor=Packages that will be ignored, divided by \":\".    Default value:vendor"
-  echo ""
-  echo "Step 2: running GCatch on a buggy version of grpc in testdata"
-  echo "Note: all bugs reported below should be real BMOC bugs"
-  echo "$GCATCH -path=$GOPATH/src/google.golang.org/grpc -include=google.golang.org/grpc -checker=BMOC -r"
-  $GCATCH -path=$GOPATH/src/google.golang.org/grpc -include=google.golang.org/grpc -checker=BMOC -r
+#!/usr/bin/env bash
+#
+# Run GCatch to check the buggy grpc
+# Before running this script, run installZ3.sh and then install.sh
+# GCatch currently only supports GOPATH instead of go.mod due to legacy issues
+# GCatch turns off the usage of go module
+# The project to be checked must be located in the corresponding GOPATH
 
+echo "Make sure you have run installZ3.sh and then install.sh"
+
+# check if z3 installed
+if ! command -v z3 >/dev/null; then
+  echo "Cannot detect z3. Run installZ3.sh to install z3 from sources"
 fi
+
+# check if z3 header installed
+if ! echo '#include <z3.h>' | gcc -H -fsyntax-only -E - 1>/dev/null 2>&1; then
+  echo "Cannot detect <z3.h>. Run installZ3.sh to install z3 from sources"
+fi
+
+# cd script directory
+CURDIR="$(dirname "$(realpath "$0")")"
+cd "$CURDIR" || exit 1
+
+GCATCH="$(cd ../../../../.. || exit 1; pwd)/bin/GCatch"
+
+# check if GCatch installed
+if ! test -f "$GCATCH"; then
+  echo "GCatch is not installed. Run install.sh to install it under $GCATCH"
+  exit 1
+fi
+
+# turn off go mod before checking
+export GO111MODULE=off
+
+echo "Step 1: setting GOPATH of the checked grpc"
+export GOPATH=$CURDIR/testdata/grpc-buggy
+echo "GOPATH is set to $GOPATH"
+echo ""
+echo "Description of flags of GCatch:"
+echo "Required Flag: -path=Full path of the application to be checked"
+echo "Required Flag: -include=Relative path (what's after /src/) of the application to be checked"
+echo "Required Flag: -checker=The checkers you want to run, divided by \":\".    Default value:BMOC"
+echo "Optional Flag: -r    Whether all children packages should also be checked recursively"
+echo "Optional Flag: -compile-error    Whether compilation errors should be printed, if there are any"
+echo "Optional Flag: -vendor=Packages that will be ignored, divided by \":\".    Default value:vendor"
+echo ""
+echo "Step 2: running GCatch on a buggy version of grpc in testdata"
+echo "Note: all bugs reported below should be real BMOC bugs"
+echo "$GCATCH -path=$GOPATH/src/google.golang.org/grpc -include=google.golang.org/grpc -checker=BMOC -r"
+$GCATCH -path="$GOPATH"/src/google.golang.org/grpc -include=google.golang.org/grpc -checker=BMOC -r


### PR DESCRIPTION
This PR basically solves #23 Task 2:
Improve scripts
1. Check if z3.h exists, which **partly** helps to check if z3 is installed from sources.
2. "export GO111MODULE=off" to turn off go module support before installation and checking, otherwise, there may be building errors for higher versions of Go.
3. More detailed comments to explain the prerequisites.
4. Miscellaneous improvements in scripts.
