### PR TITLE
Fix an error in defer analysis

### DIFF
--- a/GCatch/util/cfg.go
+++ b/GCatch/util/cfg.go
@@ -44,15 +44,20 @@ func IsFnEnd(ii ssa.Instruction) bool {
 	return false
 }
 
-// according to the annotation of ssa.Function, a function only has one normal entry BB and one optional recover BB. So this function returns at most 2 inst
-func GetEntryInsts(fn * ssa.Function) [] ssa.Instruction {
+// according to the annotation of ssa.Function, a function only has one normal entry BB and one optional recover BB.
+// There is no need to analyze the recover BB. No BB can reach it and it reaches no BB
+func GetEntryInsts(fn *ssa.Function) [] ssa.Instruction {
 
 	vecResult := make([] ssa.Instruction, 0)
 
 	for _, bb := range fn.Blocks {
+		if bb.Comment == "recover" {
+			continue
+		}
 		if len(bb.Preds) == 0 {
 			if len(bb.Instrs) > 0 {
 				vecResult = append(vecResult, bb.Instrs[0])
+				break
 			}
 		}
 	}


### PR DESCRIPTION
This PR fixes a problem in our defer analysis.

***Why create this PR***
Users reported that "go-cmp causes hang in ComputeDeferMap()" #26 

After running GCatch on the file they provided, I found that the gen-kill algorithm in GCatch/util/genKill/deferAnalysis.go never stops, while it was analyzing function `(formatOptions) FormatValue` in github.com/google/go-cmp/cmp/report_reflect.go

***What this PR changes***
(1) Don't start the gen-kill algorithm in the recover BB of a function, which is a fake BB generated by the SSA building algorithm.

(2) When cleaning a task, clean all fields of it.

(3) When copying a slice, use a for loop to copy it.

(4) When comparing two maps, don't use `reflect.DeepEqual()`. Instead, I wrote a for loop to compare them.

Experiments show that (1), (2), and (4) don't cause this problem. I changed them to make the code better. 
The root cause of this problem is (3). Always use a for loop to copy a slice in Go.