### PR TITLE
Add a demo of detection of non-blocking bugs

### DIFF
--- a/GCatch/cmd/GCatch/main.go
+++ b/GCatch/cmd/GCatch/main.go
@@ -67,7 +67,7 @@ func main() {
 		case "unlock": forgetunlock.Initialize()
 		case "double": doublelock.Initialize()
 		case "conflict", "structfield", "fatal", "BMOC": // no need to initialize these checkers
-		case "chSafety":
+		case "NBMOC":
 			config.BoolChSafety = true
 		default:
 			fmt.Println("Warning, a not existing checker is in -checker= flag:", strCheckerName)

--- a/GCatch/runCheckNonBlock.sh
+++ b/GCatch/runCheckNonBlock.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Run GCatch to check two toy programs with non-blocking bugs in testdata/toyprogram/src/*Close
+# Before running this script, run installZ3.sh and then install.sh
+# GCatch currently only supports GOPATH instead of go.mod due to legacy issues
+# GCatch turns off the usage of go module
+# The project to be checked must be located in the corresponding GOPATH
+
+echo "Make sure you have run installZ3.sh and then install.sh"
+
+# check if z3 installed
+if ! command -v z3 >/dev/null; then
+  echo "Cannot detect z3. Run installZ3.sh to install z3 from sources"
+fi
+
+# check if z3 header installed
+if ! echo '#include <z3.h>' | gcc -H -fsyntax-only -E - 1>/dev/null 2>&1; then
+  echo "Cannot detect <z3.h>. Run installZ3.sh to install z3 from sources"
+fi
+
+# cd script directory
+CURDIR="$(dirname "$(realpath "$0")")"
+cd "$CURDIR" || exit 1
+
+GCATCH="$(cd ../../../../.. || exit 1; pwd)/bin/GCatch"
+
+# check if GCatch installed
+if ! test -f "$GCATCH"; then
+  echo "GCatch is not installed. Run install.sh to install it under $GCATCH"
+  exit 1
+fi
+
+# turn off go mod before checking
+export GO111MODULE=off
+
+echo "-----Step 1: setting GOPATH of the toyprogram"
+export GOPATH=$CURDIR/testdata/toyprogram
+echo "GOPATH is set to $GOPATH"
+echo ""
+echo "Description of flags of GCatch:"
+echo "Required Flag: -path=Full path of the application to be checked"
+echo "Required Flag: -include=Relative path (what's after /src/) of the application to be checked"
+echo "Required Flag: -checker=The checkers you want to run, divided by \":\".    Default value:BMOC"
+echo "Optional Flag: -r    Whether all children packages should also be checked recursively"
+echo "Optional Flag: -compile-error    Whether compilation errors should be printed, if there are any"
+echo "Optional Flag: -vendor=Packages that will be ignored, divided by \":\".    Default value:vendor"
+echo ""
+
+echo "-----Step 2.1: running GCatch on testdata/toyprogram/src/doubleClose"
+echo "GO111MODULE=off $GCATCH -path="$GOPATH"/src/doubleClose -include=doubleClose -checker=BMOC:NBMOC -r"
+GO111MODULE=off $GCATCH -path="$GOPATH"/src/doubleClose -include=doubleClose -checker=BMOC:NBMOC -r
+echo ""
+echo "-----Step 2.2: running GCatch on testdata/toyprogram/src/sendAfterClose"
+echo "GO111MODULE=off $GCATCH -path="$GOPATH"/src/sendAfterClose -include=sendAfterClose -checker=BMOC:NBMOC -r"
+GO111MODULE=off $GCATCH -path="$GOPATH"/src/sendAfterClose -include=sendAfterClose -checker=BMOC:NBMOC -r

--- a/GCatch/syncgraph/check.go
+++ b/GCatch/syncgraph/check.go
@@ -73,6 +73,9 @@ func (g SyncGraph) CheckWithZ3() bool {
 						fmt.Print("----------Bug[")
 						fmt.Print(config.BugIndex)
 						fmt.Print("]----------\n\tType: Channel Safety \tReason: Double close.\n")
+						fmt.Println("Location of closes:")
+						output.PrintIISrc(aClose.Inst)
+						output.PrintIISrc(bClose.Inst)
 						return true
 					}
 				}
@@ -305,7 +308,7 @@ func (g SyncGraph) CheckWithZ3() bool {
 
 				for _, blockPos := range blockPosComb {
 					if blockPos.pNodeId != emptyPNodeId {
-						fmt.Println("-----Blocking Path NO.", blockPos.pathId)
+						fmt.Println("-----Blocking/Panic Path NO.", blockPos.pathId)
 						paths[blockPos.pathId].PrintPPath()
 					} else {
 						fmt.Println("-----Path NO.", blockPos.pathId, "\tEntry func at:", goroutines[blockPos.pathId].EntryFn.String())

--- a/GCatch/syncgraph/untils.go
+++ b/GCatch/syncgraph/untils.go
@@ -454,7 +454,7 @@ func (p *PPath) PrintPPath() {
 		fmt.Print(strTypeMsg)
 		fmt.Print(" :", output.GetLoc(pn.Node.Instruction()))
 		if pn.Blocked {
-			fmt.Print("\t Blocking")
+			fmt.Print("\t Blocking/Panic")
 		} else if pn.Executed {
 			fmt.Printf("\t %q", tick)
 		} else {

--- a/GCatch/testdata/toyprogram/src/doubleClose/main.go
+++ b/GCatch/testdata/toyprogram/src/doubleClose/main.go
@@ -1,0 +1,9 @@
+package main
+
+func main() {
+	c1 := make(chan int)
+	go func() {
+		close(c1)
+	}()
+	close(c1)
+}

--- a/GCatch/testdata/toyprogram/src/sendAfterClose/main.go
+++ b/GCatch/testdata/toyprogram/src/sendAfterClose/main.go
@@ -1,0 +1,9 @@
+package main
+
+func main() {
+	c1 := make(chan int)
+	go func() {
+		c1 <- 1
+	}()
+	close(c1)
+}


### PR DESCRIPTION
Actually we already have a trigger for non-blocking bugs in current master branch.

This pull request slightly changes output, adds two toy programs of send-after-close and double-close bugs, and adds a script to run GCatch on them.

**To check non-blocking bugs**
Just run GCatch as usual, but replace flag `-checker=BMOC` with `-checker=BMOC:NBMOC`. This will run blocking-misuse-of-channel checker together with non-blocking-misuse-of-channel checker. Note that NBMOC must run together with BMOC.

**To run the demo**
`cd ./GCatch`
`./install.sh`
`./runCheckNonBlock.sh`


The output should end with text like below:

> -----Step 2.1: running GCatch on testdata/toyprogram/src/doubleClose
> GO111MODULE=off /home/ziheng/Go/mygcatch/bin/GCatch -path=/home/ziheng/Go/mygcatch/src/github.com/system-pclub/GCatch/GCatch/testdata/toyprogram/src/doubleClose -include=doubleClose -checker=BMOC:NBMOC -r
> Successfully built whole program. Now running checkers
> ----------Bug[1]----------
>         Type: Channel Safety    Reason: Double close.
> Location of closes:
>         File: /home/ziheng/Go/mygcatch/src/github.com/system-pclub/GCatch/GCatch/testdata/toyprogram/src/doubleClose/main.go:8
>         File: /home/ziheng/Go/mygcatch/src/github.com/system-pclub/GCatch/GCatch/testdata/toyprogram/src/doubleClose/main.go:6
> Now trying to build unchecked packages separately...
> 
> 
> Time of main(): seconds 0.036387144
> 
> -----Step 2.2: running GCatch on testdata/toyprogram/src/sendAfterClose
> GO111MODULE=off /home/ziheng/Go/mygcatch/bin/GCatch -path=/home/ziheng/Go/mygcatch/src/github.com/system-pclub/GCatch/GCatch/testdata/toyprogram/src/sendAfterClose -include=sendAfterClose -checker=BMOC:NBMOC -r
> Successfully built whole program. Now running checkers
> ----------Bug[1]----------
>         Type: BMOC/Channel Safety       Reason: One or multiple channel operation is blocked/panic.
> -----Blocking/Panic at:
>         File: /home/ziheng/Go/mygcatch/src/github.com/system-pclub/GCatch/GCatch/testdata/toyprogram/src/sendAfterClose/main.go:6
> -----Path NO. 0         Entry func at: sendAfterClose.main
> ChanMake :/home/ziheng/Go/mygcatch/src/github.com/system-pclub/GCatch/GCatch/testdata/toyprogram/src/sendAfterClose/main.go:4:12         '✓'
> Go :/home/ziheng/Go/mygcatch/src/github.com/system-pclub/GCatch/GCatch/testdata/toyprogram/src/sendAfterClose/main.go:5:2        '✓'
> Chan_op :/home/ziheng/Go/mygcatch/src/github.com/system-pclub/GCatch/GCatch/testdata/toyprogram/src/sendAfterClose/main.go:8:7   '✓'
> Return :/home/ziheng/Go/mygcatch/src/github.com/system-pclub/GCatch/GCatch/testdata/toyprogram/src/sendAfterClose/main.go:8:7    '✓'
> -----Blocking/Panic Path NO. 1
> Chan_op :/home/ziheng/Go/mygcatch/src/github.com/system-pclub/GCatch/GCatch/testdata/toyprogram/src/sendAfterClose/main.go:6:6   Blocking/Panic
> Return :/home/ziheng/Go/mygcatch/src/github.com/system-pclub/GCatch/GCatch/testdata/toyprogram/src/sendAfterClose/main.go:6:6    '✗'
> 
> Now trying to build unchecked packages separately...
